### PR TITLE
use include_once instead of include

### DIFF
--- a/src/Afip.php
+++ b/src/Afip.php
@@ -247,7 +247,7 @@ class Afip {
 				if (!file_exists($file)) 
 					throw new Exception("Failed to open ".$file."\n", 1);
 
-				include $file;
+				include_once $file;
 
 				return ($this->{$property} = new $property($this));
 			}


### PR DESCRIPTION
Este es un cambio menor, pero al utilizar `include_once` en vez de `include` puedo crear dos instancias de la clase en el mismo request o por ejemplo dentro de laravel tinker.

No estoy muy seguro de que sea la mejor forma, no soy muy ducho en php, pero con esto no me da error 😬

saludos y gracias por hacer esta librería