### PR TITLE
Log configurable

### DIFF
--- a/src/Afip.php
+++ b/src/Afip.php
@@ -113,6 +113,10 @@ class Afip {
 		if (!isset($options['exceptions'])) {
 			$options['exceptions'] = FALSE;
 		}
+		
+		if (!isset($options['log'])) {
+			$options['log'] = '';
+		}
 
 		if (!isset($options['cert'])) {
 			$options['cert'] = 'cert';

--- a/src/Afip.php
+++ b/src/Afip.php
@@ -83,6 +83,13 @@ class Afip {
 		'RegisterScopeTen',
 		'RegisterScopeThirteen'
 	);
+	
+	/**
+	 * Route to save logs.
+	 *
+	 * @var string
+	 **/
+	var $log;
 
 	function __construct($options)
 	{
@@ -465,9 +472,36 @@ class AfipWebService
 
 		$results = $this->soap_client->{$operation}($params);
 
+		$this->_Log($operation, $results);
 		$this->_CheckErrors($operation, $results);
 
 		return $results;
+	}
+	
+	/**
+	 * If activated logs the request and response
+	 *
+	 * @since 0.7.5
+	 *
+	 * @param string 	$operation 	SOAP operation to check
+	 * @param mixed 	$results 	AFIP response
+	 *
+	 * @return void
+	 **/
+	private function _Log($operation, $results)
+	{
+        	$route = $this->afip->options['log'];
+        	if (!is_dir($route) or !is_writable($route)) {
+        		return;
+        	}
+        	$request = $this->soap_client->__getLastRequest();
+        	$response = $this->soap_client->__getLastResponse();
+		$micro = explode(" ", microtime())[0];
+        	$folder = "$route/$operation/" . date('Y-m-d--H-i-s-') . str_replace("0.", "", $micro);
+		mkdir($folder, 0777, true);
+
+        	file_put_contents("$folder/request.xml", $request);
+        	file_put_contents("$folder/response.xml", $response);
 	}
 
 	/**


### PR DESCRIPTION
Se agrega la opción de poder indicar una ruta donde guardar logs de peticiones y respuestas. Ideal para cuando hay que reclamar algo a AFIP.

Cada petición y respuesta se guarda con el siguiente formato:
/ruta-configurada/{operation}/{año-mes-dia--hora-minuto-microsegundos}/requesta.xml
/ruta-configurada/{operation}/{año-mes-dia--hora-minuto-microsegundos}/response.xml

Ejemplos
- /var/log/FECompUltimoAutorizado/2022-08-23--09-29-42-69354100/request.xml
- /var/log/FECompUltimoAutorizado/2022-08-23--09-29-42-69354100/response.xml
- /var/log/FECompConsultar/2022-08-23--09-29-42-69354100/request.xml
- /var/log/FECompConsultar/2022-08-23--09-29-42-69354100/response.xml

Por defecto queda desactivado y en caso de ser aprobado y fusionado debería actualizarse la Wiki acá: https://github.com/AfipSDK/afip.php/wiki/Primeros-pasos
De paso pueden corregir el parámetro "exceptions" en la Wiki que es `bool` y no `string`.